### PR TITLE
Extension point to provide data source information.

### DIFF
--- a/DataSourceInfoProviderAttribute.cs
+++ b/DataSourceInfoProviderAttribute.cs
@@ -1,0 +1,35 @@
+﻿using System;
+
+namespace Saraff.Twain.DS
+{
+    public interface IDataSourceInfo
+    {
+        Version Version { get; }
+        string Company { get; }
+        string ProductFamily { get; }
+        string ProductName { get; }
+    }
+
+    /// <summary>
+    /// Specifies type that is responsible to provide custom data source information.
+    /// The given type should implement <see cref="IDataSourceInfo"/> interface.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    public class DataSourceInfoProviderAttribute : Attribute
+    {
+        public Type Type { get; }
+
+        public DataSourceInfoProviderAttribute(Type type)
+        {
+            Type = type;
+        }
+    }
+
+    public class DataSourceInfo : IDataSourceInfo
+    {
+        public Version Version { get; set; }
+        public string Company { get; set; }
+        public string ProductFamily { get; set; }
+        public string ProductName { get; set; }
+    }
+}

--- a/Saraff.Twain.DS.csproj
+++ b/Saraff.Twain.DS.csproj
@@ -84,6 +84,7 @@
     <Compile Include="Capabilities\ThresholdDataSourceCapabilitiy.cs" />
     <Compile Include="Capabilities\XferMechAttribute.cs" />
     <Compile Include="CapabilityEventArgs.cs" />
+    <Compile Include="DataSourceInfoProviderAttribute.cs" />
     <Compile Include="DataSourceInstaller.cs">
       <SubType>Component</SubType>
     </Compile>


### PR DESCRIPTION
Added extension point to provide data source information by user-provided class.

Existing solution with assembly-level attributes is static, but sometimes it needs to be read from some external source (config file, registry etc).

Example usage:
```
public class AppInfo : IDataSourceInfo
{
        public Version Version { get; } = new Version();
        public string Company { get; }
        public string ProductFamily { get; }
        public string ProductName { get; }

        public AppInfo()
        {
            // Somehow read data source information...
        }
    }
}

[DataSourceInfoProvider(typeof(AppInfo))]
public sealed class MyCoolBitmapDataSource : BitmapDataSource, IDisposable
{
    ...
}
```

